### PR TITLE
fix: add apikey query parameter to login endpoint

### DIFF
--- a/cozi/__init__.py
+++ b/cozi/__init__.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 # urls
 URL_BASE = "https://rest.cozi.com"
-URL_LOGIN = "{}/api/ext/2207/auth/login".format(URL_BASE)
+URL_LOGIN = "{}/api/ext/2207/auth/login?apikey=coziwc|v251_production".format(URL_BASE)
 URL_PERSON = "{}/api/ext/2004/{}/account/person/"
 URL_LISTS = "{}/api/ext/2004/{}/list/"
 URL_LIST = "{}/api/ext/2004/{}/list/{}"


### PR DESCRIPTION
The Cozi API now requires an apikey query parameter on the login endpoint. Without it, Cloudflare returns a 408 Request Timeout.

Discovered by capturing network traffic from the working web client at my.cozi.com.

----

AI discovered and fixed with human in the loop. Appears to fix at least for me. The API key probably changes over time or even every release... We'll have to see if it breaks again